### PR TITLE
FEATURE: Improve highlighting in Vue files

### DIFF
--- a/Themes/NightOwls.css
+++ b/Themes/NightOwls.css
@@ -314,3 +314,31 @@ typescript.identifier.function {
 html.tag.attribute.link {
   color: #59be84;
 }
+
+/* Vue */
+
+vue.html.tag.open,
+vue.html.tag.close {
+  color: #59be84;
+}
+
+vue.html.tag.name {
+  color: #59be84;
+}
+
+vue.html.tag.attribute.shorthand-key {
+  color: #a9dc76;
+}
+
+vue.html.tag.attribute.name,
+vue.html.embedded.interpolation.bracket {
+  color: #59be84;
+}
+
+vue.html.tag.attribute.argument {
+  color: #a9dc76;
+}
+
+vue.html.tag.attribute.modifier {
+  color: #a9dc76;
+}


### PR DESCRIPTION
Hi there!

I recently refined the class selector of Vue elements in my extension. Its a new feature and not a lot of themes currently support it. If you like these changes I would love to add this theme in the list of supported ones.

<img width="1152" alt="Schermata 2020-10-27 alle 15 28 52" src="https://user-images.githubusercontent.com/25225746/97315576-25d0b680-1869-11eb-9512-7fc6cece25fc.png">
